### PR TITLE
Add functionality to fetch APIs from backend

### DIFF
--- a/src/api/util.ts
+++ b/src/api/util.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export function FetchAPI(url: string) {
+  const [result, setResult] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3000/' + url, { method: 'get' })
+      .then((res) => res.json())
+      .then((res) => {
+        setResult(res);
+      });
+  }, [url]);
+
+  return result;
+}

--- a/src/components/events.tsx
+++ b/src/components/events.tsx
@@ -1,1 +1,7 @@
-//component for events data
+export default function event(info: object) {
+  return (
+    <h2>
+      {info._id} - {info.name}
+    </h2>
+  );
+}

--- a/src/pages/PublicHome.tsx
+++ b/src/pages/PublicHome.tsx
@@ -1,8 +1,14 @@
 import { Link } from 'react-router';
-
+import { FetchAPI } from '../api/util.ts';
+import event from '../components/events.tsx';
 import '../styles/home.css';
 
 export default function PublicHome() {
+  const events = FetchAPI('events');
+
+  const info: array = [];
+  for (let i = 0; i < events.length; i++) info.push(event(events[i]));
+
   const heading: string = 'Homepage';
   return (
     <div>
@@ -15,6 +21,7 @@ export default function PublicHome() {
         <Link to="/userprofile">User Profile</Link>
         <Link to="/error">Error Page</Link>
       </div>
+      {info}
     </div>
   );
 }


### PR DESCRIPTION
### ✨ What’s Changed?

More of a proof of concept to have frontend able to use backend APIs and use its data to display in web page. Right now it only shows all of the events with id and name listed, very much can be expanded and prettier at `src/components/events.tsx`.

Requires https://github.com/fac-31/Pro0428-LocalEventBackend/pull/24 to have API working.

### 📚 Related Issues

Closes #25

### ✅ Checklist

- [x] Lint & formatting passes (`npm run lint / run lint:fix`)
- [x] No type errors (`npm run type-check`)
- [ ] Tests added or updated (if applicable)
