### PR TITLE
updated to prevent multiple discord pings for edits

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -2,7 +2,7 @@ name: Webhook on Pull Request
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, synchronize]
     branches:
       - main
 


### PR DESCRIPTION
We were getting multiple unnecessary pings when you edited your PR message, including ticking the template checkboxes. Synchronize will send a notification on new commits to the PR, not edits.