### PR TITLE
Add buttons to edit and delete events as an admin

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -21,8 +21,7 @@
     "npm:tw-animate-css@^1.3.0": "1.3.3",
     "npm:typescript-eslint@^8.26.1": "8.32.0_eslint@9.26.0_typescript@5.7.3_@typescript-eslint+parser@8.32.0__eslint@9.26.0__typescript@5.7.3",
     "npm:typescript@~5.7.2": "5.7.3",
-    "npm:vite@^6.3.1": "6.3.5_picomatch@4.0.2",
-    "npm:zod@^3.25.48": "3.25.48"
+    "npm:vite@^6.3.1": "6.3.5_picomatch@4.0.2"
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -290,7 +289,7 @@
         "express-rate-limit",
         "pkce-challenge",
         "raw-body",
-        "zod@3.24.4",
+        "zod",
         "zod-to-json-schema"
       ]
     },
@@ -1043,7 +1042,7 @@
         "minimatch@3.1.2",
         "natural-compare",
         "optionator",
-        "zod@3.24.4"
+        "zod"
       ],
       "bin": true
     },
@@ -1946,14 +1945,11 @@
     "zod-to-json-schema@3.24.5_zod@3.24.4": {
       "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
       "dependencies": [
-        "zod@3.24.4"
+        "zod"
       ]
     },
     "zod@3.24.4": {
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="
-    },
-    "zod@3.25.48": {
-      "integrity": "sha512-0X1mz8FtgEIvaxGjdIImYpZEaZMrund9pGXm3M6vM7Reba0e2eI71KPjSCGXBfwKDPwPoywf6waUKc3/tFvX2Q=="
     }
   },
   "workspace": {
@@ -1964,6 +1960,7 @@
         "npm:@types/react-dom@^19.0.4",
         "npm:@types/react@^19.0.10",
         "npm:@vitejs/plugin-react-swc@^3.8.0",
+        "npm:axios@^1.9.0",
         "npm:eslint-config-prettier@^10.1.2",
         "npm:eslint-plugin-prettier@^5.2.6",
         "npm:eslint-plugin-react-hooks@^5.2.0",
@@ -1971,6 +1968,7 @@
         "npm:eslint@^9.22.0",
         "npm:globals@16",
         "npm:lucide-react@0.511",
+        "npm:mongodb@^6.17.0",
         "npm:prettier@3.5.3",
         "npm:react-dom@19",
         "npm:react-router@^7.6.0",
@@ -1979,8 +1977,7 @@
         "npm:tw-animate-css@^1.3.0",
         "npm:typescript-eslint@^8.26.1",
         "npm:typescript@~5.7.2",
-        "npm:vite@^6.3.1",
-        "npm:zod@^3.25.48"
+        "npm:vite@^6.3.1"
       ]
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router": "^7.6.0",
-        "tailwindcss": "^4.1.6",
-        "zod": "^3.25.48"
+        "tailwindcss": "^4.1.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -4938,9 +4937,10 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.48",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.48.tgz",
-      "integrity": "sha512-0X1mz8FtgEIvaxGjdIImYpZEaZMrund9pGXm3M6vM7Reba0e2eI71KPjSCGXBfwKDPwPoywf6waUKc3/tFvX2Q==",
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.6.0",
-    "tailwindcss": "^4.1.6",
-    "zod": "^3.25.48"
+    "tailwindcss": "^4.1.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/api/services/events.ts
+++ b/src/api/services/events.ts
@@ -1,3 +1,8 @@
+import axios from 'axios';
+import api from '../api';
+
+import { Event } from 'models/event.model';
+
 export const getEventByMode = async (modes: string[]) => {
   const query = new URLSearchParams({ mode: modes.join(',') }).toString();
 
@@ -7,4 +12,32 @@ export const getEventByMode = async (modes: string[]) => {
     throw new Error('Failed to fetch events');
   }
   return response.json();
+};
+
+export const getEventById = async (id: string) => {
+  const response = await fetch(`http://localhost:3000/events/${id}`);
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch events');
+  }
+  return response.json();
+};
+
+export interface UpdateEventResponse {
+  message: string;
+}
+
+export const updateEventById = async (
+  id: string,
+  event: Event,
+): Promise<UpdateEventResponse | null> => {
+  try {
+    const { data } = await api.put<UpdateEventResponse>('/events/' + id, event);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      return null;
+    }
+    throw error;
+  }
 };

--- a/src/api/services/events.ts
+++ b/src/api/services/events.ts
@@ -41,3 +41,21 @@ export const updateEventById = async (
     throw error;
   }
 };
+
+export interface DeleteEventResponse {
+  message: string;
+}
+
+export const deleteEventById = async (
+  id: string,
+): Promise<DeleteEventResponse | null> => {
+  try {
+    const { data } = await api.delete<DeleteEventResponse>('/events/' + id);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      return null;
+    }
+    throw error;
+  }
+};

--- a/src/components/major/events.tsx
+++ b/src/components/major/events.tsx
@@ -1,10 +1,31 @@
 //component for events data
-import { Event } from 'models/event.model.ts';
+import { Link } from 'react-router';
+import { Wrench } from 'lucide-react';
 
-export default function Events(info: Event) {
+import { useAuth } from '../../auth/useAuth';
+import { FullEvent } from 'models/event.model.ts';
+
+export default function Events(info: FullEvent) {
+  const { user } = useAuth();
+  const admin = user && user.role === 'admin';
+
   return (
     <div className="p-4 m-4 border solid white rounded w-[50%]">
-      <h1 className="text-xl font-bold">{info.name}</h1>
+      <div className="flex">
+        <h1 className="w-full text-xl font-bold">{info.name}</h1>
+        {admin ? (
+          <div>
+            <Link
+              to={'/events/edit/' + info._id}
+              className={`flex gap-2 p-2 rounded-md outline-2 outline-primary hover:bg-input-bg`}
+            >
+              <Wrench />
+            </Link>
+          </div>
+        ) : (
+          ''
+        )}
+      </div>
       <p>{info.location}</p>
       <p>{info.distance}km away</p>
       <p>{new Date(info.date).toLocaleDateString()}</p>

--- a/src/components/major/eventsContainer.tsx
+++ b/src/components/major/eventsContainer.tsx
@@ -1,24 +1,15 @@
 import Events from './events';
-import { Event } from 'models/event.model';
+import { FullEvent } from 'models/event.model';
 
 type Props = {
-  events: Event[];
+  events: FullEvent[];
 };
 
 const EventsContainer = ({ events }: Props) => {
   return (
     <div className="flex flex-col grow items-center mt-12">
-      {events.map((event) => (
-        <Events
-          mode={event.mode}
-          name={event.name}
-          date={event.date}
-          price={event.price}
-          description={event.description}
-          distance={event.distance}
-          location={event.location}
-          url={event.url}
-        />
+      {events.map((event: FullEvent) => (
+        <Events {...event} />
       ))}
     </div>
   );

--- a/src/components/minor/FormInput.tsx
+++ b/src/components/minor/FormInput.tsx
@@ -1,15 +1,17 @@
-type InputType = 'text' | 'email' | 'password';
+type InputType = 'text' | 'email' | 'number' | 'password';
 
 interface FormInputProps {
   name: string;
   label: string;
+  def?: string | number;
   type?: InputType;
-  error: boolean;
+  error?: boolean;
 }
 
 export default function FormInput({
   name,
   label,
+  def = '',
   type = 'text',
   error = false,
 }: FormInputProps) {
@@ -20,6 +22,7 @@ export default function FormInput({
         type={type}
         id={name}
         name={name}
+        defaultValue={def}
         required
         className={`bg-[var(--color-input-bg)] text-[var(--color-text)] outline-none pl-1 border ${
           error

--- a/src/config/router.tsx
+++ b/src/config/router.tsx
@@ -7,6 +7,7 @@ import UserHome from '../pages/UserHome';
 import UserProfile from '../pages/UserProfile';
 import Error from '../pages/Error';
 import SavedEvents from '../pages/SavedEvents';
+import EditEvent from '../pages/EditEvent';
 
 const router = createBrowserRouter([
   {
@@ -32,6 +33,10 @@ const router = createBrowserRouter([
   {
     path: '/savedevents/:mode?',
     element: <SavedEvents />,
+  },
+  {
+    path: '/events/edit/:id',
+    element: <EditEvent />,
   },
   {
     path: '/*',

--- a/src/hooks/useEventById.ts
+++ b/src/hooks/useEventById.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+import { getEventById } from '../api/services/events';
+import { Event } from 'models/event.model';
+
+export const useEventById = (id: string) => {
+  const [event, setEvent] = useState<Event>();
+
+  useEffect(() => {
+    const getEvent = async () => {
+      try {
+        const data = await getEventById(id);
+        setEvent(data);
+      } catch (error) {
+        new Error('Error setting event by id: ' + error);
+      }
+    };
+    getEvent();
+  }, [id]);
+
+  return { event, setEvent };
+};

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -2,11 +2,11 @@ import { useState, useEffect } from 'react';
 import { FiltersState } from '../components/major/side-bar/types';
 import { getEventByMode } from '../api/services/events';
 import { filterEvents } from '../utils/filterEvents';
-import { Event } from 'models/event.model';
+import { FullEvent } from 'models/event.model';
 
 export const useEvents = (filters: FiltersState) => {
-  const [rawEvents, setRawEvents] = useState<Event[]>([]);
-  const [filteredEvents, setFilteredEvents] = useState<Event[]>([]);
+  const [rawEvents, setRawEvents] = useState<FullEvent[]>([]);
+  const [filteredEvents, setFilteredEvents] = useState<FullEvent[]>([]);
 
   useEffect(() => {
     const getEvents = async () => {

--- a/src/pages/EditEvent.tsx
+++ b/src/pages/EditEvent.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useParams } from 'react-router';
+import { updateEventById } from '../api/services/events.ts';
+import { useEventById } from '../hooks/useEventById.ts';
+
+import '../styles/home.css';
+import NavBar from '../components/major/nav-bar';
+import FormInput from '../components/minor/FormInput';
+
+import { Event } from 'models/event.model.ts';
+
+export default function EditEvent() {
+  let { id } = useParams();
+  if (id === undefined) id = '';
+
+  const eventId: string = id;
+  const { event } = useEventById(eventId);
+  const [formData, setFormData] = useState<Event | null>(null);
+  const [message, setMessage] = useState('');
+
+  if (!event) return;
+
+  if (formData === null) {
+    const data: Event = {
+      mode: event.mode,
+      name: event.name,
+      description: event.description,
+      location: event.location,
+      date: event.date,
+      price: event.price,
+      distance: event.distance,
+      url: event.url,
+    };
+
+    setFormData(data);
+  }
+
+  const handleChange = (e: React.FormEvent) => {
+    const { name, value } = e.target as HTMLInputElement;
+    setFormData((prevState) =>
+      prevState ? { ...prevState, [name]: value } : null,
+    );
+  };
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!formData) return;
+
+    const result = await updateEventById(eventId, formData);
+    if (result && result.message) setMessage(result.message);
+  }
+
+  return (
+    <div>
+      <NavBar />
+
+      <div className="flex min-h-screen">
+        <div className="m-auto w-full max-w-md px-4">
+          <div className="border-b-3 border-t-3">
+            <div className="flex mt-3 mb-3">
+              <form
+                className="inline-block m-auto"
+                onChange={handleChange}
+                onSubmit={handleSubmit}
+              >
+                <FormInput
+                  name="mode"
+                  label="Mode"
+                  def={event.mode}
+                ></FormInput>
+
+                <FormInput
+                  name="name"
+                  label="Name"
+                  def={event.name}
+                ></FormInput>
+
+                <FormInput
+                  name="description"
+                  label="Description"
+                  def={event.description}
+                ></FormInput>
+
+                <FormInput
+                  name="location"
+                  label="Location"
+                  def={event.location}
+                ></FormInput>
+
+                <FormInput
+                  name="date"
+                  label="Date"
+                  def={event.date}
+                ></FormInput>
+                <FormInput
+                  name="price"
+                  label="Price"
+                  def={event.price}
+                  type="number"
+                ></FormInput>
+
+                <FormInput
+                  name="distance"
+                  label="Distance"
+                  def={event.distance}
+                  type="number"
+                ></FormInput>
+
+                <FormInput name="url" label="URL" def={event.url}></FormInput>
+
+                <div>
+                  <input
+                    className="uppercase w-full text-[var(--color-text)] border border-[var(--color-text)]"
+                    type="submit"
+                    value="Update Event"
+                  ></input>
+                </div>
+              </form>
+            </div>
+          </div>
+          {message && (
+            <div className="font-semibold min-h-[3.5rem] text-[var(--color-text)] whitespace-pre-line text-center mt-5">
+              {message}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -2,3 +2,8 @@
   display: flex;
   justify-content: space-around;
 }
+
+.popup {
+  background: var(--color-background);
+  border-radius: 1rem;
+}

--- a/src/utils/filterEvents.ts
+++ b/src/utils/filterEvents.ts
@@ -1,8 +1,8 @@
-import { Event } from 'models/event.model';
+import { FullEvent } from 'models/event.model';
 import { FiltersState } from '../components/major/side-bar/types';
 
-export const filterEvents = (events: Event[], filters: FiltersState) => {
-  return events.filter((event: Event) => {
+export const filterEvents = (events: FullEvent[], filters: FiltersState) => {
+  return events.filter((event: FullEvent) => {
     const searchMatch =
       filters.search === '' ||
       event.name


### PR DESCRIPTION
### ✨ What’s Changed?

Making use of https://github.com/fac-31/Pro0428-LocalEventBackend/pull/41 to allow admin edit and delete events through the frontend.

When logging in as an admin, two buttons showed up at each event cards. Edit button redirects to a new page to allow change values, while delete button shows a popup on whenever to confirm delete.

### 📚 Related Issues

None

### ✅ Checklist

- [x] Lint & formatting passes (`npm run lint / run lint:fix`)
- [x] No type errors (`npm run type-check`)
- [ ] Tests added or updated (if applicable)
